### PR TITLE
HiPay Multi Accounts Integration

### DIFF
--- a/cartridges/int_hipay/cartridge/scripts/init/hiPayServiceInit.ds
+++ b/cartridges/int_hipay/cartridge/scripts/init/hiPayServiceInit.ds
@@ -9,7 +9,7 @@ var HTTPClient = require('dw/net/HTTPClient');
 var Encoding = require('dw/crypto/Encoding');
 var Bytes = require('dw/util/Bytes');
 
-/* HiPay REST Hosted Payment Service Registry */
+/* HiPay REST Hosted Payment Default Service Registry */
 ServiceRegistry.configure("hipay.rest.hpayment", {
 	createRequest: function(svc: HTTPService, args) {
 		svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -32,7 +32,7 @@ ServiceRegistry.configure("hipay.rest.hpayment", {
 	mockCall: function(svc: HTTPService, client: HTTPClient) {}
 });
 
-/* HiPay Generate Token Service Registry */
+/* HiPay Generate Token Default Service Registry */
 ServiceRegistry.configure("hipay.rest.createtoken", {
 	createRequest: function(svc: HTTPService, args) {
 		svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -55,7 +55,7 @@ ServiceRegistry.configure("hipay.rest.createtoken", {
 	mockCall: function(svc: HTTPService, client: HTTPClient) {}
 });
 
-/* HiPay Order Service */
+/* HiPay Order Default Service Registry */
 ServiceRegistry.configure("hipay.rest.order", {
 	createRequest: function(svc: HTTPService, args) {
 		svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -78,7 +78,7 @@ ServiceRegistry.configure("hipay.rest.order", {
 	mockCall: function(svc: HTTPService, client: HTTPClient) {}
 });
 
-/* HiPay REST Maintenance Service Registry */
+/* HiPay REST Maintenance Default Service Registry */
 ServiceRegistry.configure("hipay.rest.maintenance", {
 	createRequest: function(svc: HTTPService, args) {
 		svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -100,3 +100,105 @@ ServiceRegistry.configure("hipay.rest.maintenance", {
 	},
 	mockCall: function(svc: HTTPService, client: HTTPClient) {}
 });
+
+/**
+
+ Example for multi-hipay accounts integration.
+
+ Uncomment this section to make it available and change `SiteGenesis` to your specific site ID.
+ Duplicate code below and provide another site ID, if you need more hipay account configurations for specific sites;
+ Add in bm: services,profiles,credentials with proper naming, for example `hipay.rest.hpayment.SiteGenesis` service name
+ should be created in SiteGenesis site with profile and credentials for current site.
+
+ // HiPay REST Hosted Payment SiteGenesis Service Registry
+ ServiceRegistry.configure("hipay.rest.hpayment.SiteGenesis", {
+	createRequest: function(svc: HTTPService, args) {
+	svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
+	svc.addHeader("Cache-Control", "no-cache");
+	svc.addHeader("Accept", "application/json");
+
+	var serviceConfig: ServiceConfig = svc.getConfiguration();
+	var credentials: ServiceCredential = serviceConfig.getCredential();
+	var credString = credentials.getUser() + ":" + credentials.getPassword();
+	var base64Credentials = Encoding.toBase64(new Bytes(credString));
+	svc.addHeader("Authentication", "Basic " + base64Credentials);
+
+	svc.setRequestMethod("POST");
+
+	return args;
+},
+parseResponse: function(svc: HTTPService, client: HTTPClient) {
+	return client;
+},
+mockCall: function(svc: HTTPService, client: HTTPClient) {}
+});
+
+ // HiPay Generate Token SiteGenesis Service Registry
+ ServiceRegistry.configure("hipay.rest.createtoken.SiteGenesis", {
+	createRequest: function(svc: HTTPService, args) {
+	svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
+	svc.addHeader("Cache-Control", "no-cache");
+	svc.addHeader("Accept", "application/json");
+
+	var serviceConfig: ServiceConfig = svc.getConfiguration();
+	var credentials: ServiceCredential = serviceConfig.getCredential();
+	var credString = credentials.getUser() + ":" + credentials.getPassword();
+	var base64Credentials = Encoding.toBase64(new Bytes(credString));
+	svc.addHeader("Authentication", "Basic " + base64Credentials);
+
+	svc.setRequestMethod("POST");
+
+	return args;
+},
+parseResponse: function(svc: HTTPService, client: HTTPClient) {
+	return client;
+},
+mockCall: function(svc: HTTPService, client: HTTPClient) {}
+});
+
+ // HiPay Order SiteGenesis Service Registry
+ ServiceRegistry.configure("hipay.rest.order.SiteGenesis", {
+	createRequest: function(svc: HTTPService, args) {
+	svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
+	svc.addHeader("Cache-Control", "no-cache");
+	svc.addHeader("Accept", "application/json");
+
+	var serviceConfig: ServiceConfig = svc.getConfiguration();
+	var credentials: ServiceCredential = serviceConfig.getCredential();
+	var credString = credentials.getUser() + ":" + credentials.getPassword();
+	var base64Credentials = Encoding.toBase64(new Bytes(credString));
+	svc.addHeader("Authentication", "Basic " + base64Credentials);
+
+	svc.setRequestMethod("POST");
+
+	return args;
+},
+parseResponse: function(svc: HTTPService, client: HTTPClient) {
+	return client;
+},
+mockCall: function(svc: HTTPService, client: HTTPClient) {}
+});
+
+ // HiPay REST Maintenance SiteGenesis Service Registry
+ ServiceRegistry.configure("hipay.rest.maintenance.SiteGenesis", {
+	createRequest: function(svc: HTTPService, args) {
+	svc.addHeader("Content-Type", "application/x-www-form-urlencoded");
+	svc.addHeader("Cache-Control", "no-cache");
+	svc.addHeader("Accept", "application/json");
+
+	var serviceConfig: ServiceConfig = svc.getConfiguration();
+	var credentials: ServiceCredential = serviceConfig.getCredential();
+	var credString = credentials.getUser() + ":" + credentials.getPassword();
+	var base64Credentials = Encoding.toBase64(new Bytes(credString));
+	svc.addHeader("Authentication", "Basic " + base64Credentials);
+
+	svc.setRequestMethod("POST");
+
+	return args;
+},
+parseResponse: function(svc: HTTPService, client: HTTPClient) {
+	return client;
+},
+mockCall: function(svc: HTTPService, client: HTTPClient) {}
+});
+ */

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayHostedService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayHostedService.ds
@@ -1,12 +1,20 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
+var Site = require('dw/system/Site');
 /**
 * Initiates HiPay hosted payment request.
 */
 function HiPayHostedService() {}
 
 HiPayHostedService.prototype.loadHostedPayment = function(params, serviceName: String) {
-	var service : HTTPService = ServiceRegistry.get(serviceName);
+	//get current ID of the site.
+	var siteId : String = Site.getCurrent().getID();
+	//try create service for current site
+	var service : HTTPService = ServiceRegistry.get(serviceName+"."+siteId);
+	//get default service if service for current site  was not configured in BM
+	if (service==null) {
+		service = ServiceRegistry.get(serviceName);
+	}
 
 	var content = "";
 	for (var param in params) { 

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayMaintenanceService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayMaintenanceService.ds
@@ -1,5 +1,6 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
+var Site = require('dw/system/Site');
 
 /**
 * HiPayMaintenanceService.ds object initiates HiPay maintenance request.
@@ -14,8 +15,15 @@ HiPayMaintenanceService.OPERATION_CAPTURE = "capture";
 * Initiates HiPay hosted payment request.
 */
 HiPayMaintenanceService.prototype.initiateCapture = function( transactionReference, operation, amount ) {
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.maintenance");
-	
+	//get current ID of the site.
+	var siteId : String = Site.getCurrent().getID();
+	//try create service for current site
+	var service : HTTPService = ServiceRegistry.get("hipay.rest.maintenance"+"."+siteId);
+	//get default service if service for current site  was not configured in BM
+	if (service==null) {
+		service = ServiceRegistry.get("hipay.rest.maintenance");
+	}
+
 	service.URL += transactionReference;
 	var content = "operation=" + operation;
 	if(!empty(amount)) {

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayOrderService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayOrderService.ds
@@ -1,5 +1,6 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
+var Site = require('dw/system/Site');
 
 /**
 * Initiates HiPay order request.
@@ -7,7 +8,14 @@ var ServiceRegistry = require('dw/svc/ServiceRegistry');
 function HiPayOrderService() {}
 
 HiPayOrderService.prototype.loadOrderPayment = function(params) {
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.order");
+	//get current ID of the site.
+	var siteId : String = Site.getCurrent().getID();
+	//try create service for current site
+	var service : HTTPService = ServiceRegistry.get("hipay.rest.order"+"."+siteId);
+	//get default service if service for current site  was not configured in BM
+	if (service==null) {
+		service = ServiceRegistry.get("hipay.rest.order");
+	}
 
 	var content = "";
 	for (var param in params) { 

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayTokenService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayTokenService.ds
@@ -1,5 +1,6 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
+var Site = require('dw/system/Site');
 
 /**
 * Initiates HiPay Token Generation request.
@@ -7,7 +8,14 @@ var ServiceRegistry = require('dw/svc/ServiceRegistry');
 function HiPayTokenService() {}
 
 HiPayTokenService.prototype.generateToken = function(params) {
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.createtoken");
+	//get current ID of the site.
+	var siteId : String = Site.getCurrent().getID();
+	//try create service for current site
+	var service : HTTPService = ServiceRegistry.get("hipay.rest.createtoken"+"."+siteId);
+	//get default service if service for current site  was not configured in BM
+	if (service==null) {
+		service = ServiceRegistry.get("hipay.rest.createtoken");
+	}
 
 	var content = "";
 	for (var param in params) { 


### PR DESCRIPTION
-Added logic to detect siteId and try to call specific service. If service doesn't exist, call default one.
-Site services should follow naming template: {default_service_name}.{siteID}
-Added comments
-Added example with SiteGenesis site ID, how HiPay multi account integration should be done.
-Solution works with single HiPay account for all sites without additional service changes in code or in bm.