### PR TITLE
Fix for multiple hipay accounts

### DIFF
--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayHostedService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayHostedService.ds
@@ -1,6 +1,8 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
 var Site = require('dw/system/Site');
+var Logger = require('dw/system/Logger');
+
 /**
 * Initiates HiPay hosted payment request.
 */
@@ -10,7 +12,11 @@ HiPayHostedService.prototype.loadHostedPayment = function(params, serviceName: S
 	//get current ID of the site.
 	var siteId : String = Site.getCurrent().getID();
 	//try create service for current site
-	var service : HTTPService = ServiceRegistry.get(serviceName+"."+siteId);
+	try {
+		var service : HTTPService = ServiceRegistry.get(serviceName+"."+siteId);
+	} catch (e) {
+		Logger.warn("Service {0}, doesn't exist", serviceName+"."+siteId);
+	}
 	//get default service if service for current site  was not configured in BM
 	if (service==null) {
 		service = ServiceRegistry.get(serviceName);

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayMaintenanceService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayMaintenanceService.ds
@@ -1,6 +1,7 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
 var Site = require('dw/system/Site');
+var Logger = require('dw/system/Logger');
 
 /**
 * HiPayMaintenanceService.ds object initiates HiPay maintenance request.
@@ -18,7 +19,11 @@ HiPayMaintenanceService.prototype.initiateCapture = function( transactionReferen
 	//get current ID of the site.
 	var siteId : String = Site.getCurrent().getID();
 	//try create service for current site
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.maintenance"+"."+siteId);
+	try {
+		var service : HTTPService = ServiceRegistry.get("hipay.rest.maintenance"+"."+siteId);
+	} catch (e) {
+		Logger.warn("Service {0}, doesn't exist", "hipay.rest.maintenance"+"."+siteId);
+	}
 	//get default service if service for current site  was not configured in BM
 	if (service==null) {
 		service = ServiceRegistry.get("hipay.rest.maintenance");

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayOrderService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayOrderService.ds
@@ -1,6 +1,7 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
 var Site = require('dw/system/Site');
+var Logger = require('dw/system/Logger');
 
 /**
 * Initiates HiPay order request.
@@ -11,7 +12,11 @@ HiPayOrderService.prototype.loadOrderPayment = function(params) {
 	//get current ID of the site.
 	var siteId : String = Site.getCurrent().getID();
 	//try create service for current site
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.order"+"."+siteId);
+	try {
+		var service : HTTPService = ServiceRegistry.get("hipay.rest.order"+"."+siteId);
+	} catch (e) {
+		Logger.warn("Service {0}, doesn't exist", "hipay.rest.order"+"."+siteId);
+	}
 	//get default service if service for current site  was not configured in BM
 	if (service==null) {
 		service = ServiceRegistry.get("hipay.rest.order");

--- a/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayTokenService.ds
+++ b/cartridges/int_hipay/cartridge/scripts/lib/hipay/services/HiPayTokenService.ds
@@ -1,6 +1,7 @@
 var HTTPService = require('dw/svc/HTTPService');
 var ServiceRegistry = require('dw/svc/ServiceRegistry');
 var Site = require('dw/system/Site');
+var Logger = require('dw/system/Logger');
 
 /**
 * Initiates HiPay Token Generation request.
@@ -11,7 +12,11 @@ HiPayTokenService.prototype.generateToken = function(params) {
 	//get current ID of the site.
 	var siteId : String = Site.getCurrent().getID();
 	//try create service for current site
-	var service : HTTPService = ServiceRegistry.get("hipay.rest.createtoken"+"."+siteId);
+	try {
+		var service : HTTPService = ServiceRegistry.get("hipay.rest.createtoken"+"."+siteId);
+	} catch (e) {
+		Logger.warn("Service {0}, doesn't exist", "hipay.rest.createtoken"+"."+siteId);
+	}
 	//get default service if service for current site  was not configured in BM
 	if (service==null) {
 		service = ServiceRegistry.get("hipay.rest.createtoken");


### PR DESCRIPTION
During some tests with different configs I found small issue. This is a fix for multiple HiPay accounts, added maintains for old/default configurations in BM. If no special service for site will be found, default one will be used instead and warning log will be added.

Regards,
Oleg